### PR TITLE
Implement the get leaderboard records endpoint

### DIFF
--- a/src/main/kotlin/com/example/plugins/Routing.kt
+++ b/src/main/kotlin/com/example/plugins/Routing.kt
@@ -4,6 +4,7 @@ import com.example.routes.auth.github.client.GithubClient
 import com.example.routes.auth.oidc
 import com.example.routes.auth.user
 import com.example.routes.githubEvents.githubEvents
+import com.example.routes.leaderboard.leaderboard
 import com.example.routes.session.session
 import com.example.routes.sprints.sprints
 import com.example.routes.tasks.tasks
@@ -72,6 +73,7 @@ fun Application.configureRouting(
         githubEvents(context)
         tasks(context)
         sprints(context)
+        leaderboard(context)
     }
     intercept(ApplicationCallPipeline.Monitoring) {
         interceptExceptions(this, LoggerFactory.getLogger(Application::class.java))

--- a/src/main/kotlin/com/example/routes/leaderboard/dtos.kt
+++ b/src/main/kotlin/com/example/routes/leaderboard/dtos.kt
@@ -1,0 +1,12 @@
+package com.example.routes.leaderboard
+
+import com.example.routes.githubEvents.GithubUser
+
+enum class LeaderboardPeriod {
+    current, last, all
+}
+
+class LeaderboardRecord(
+    val points: Int,
+    val user: GithubUser
+)

--- a/src/main/kotlin/com/example/routes/leaderboard/leaderboardRouter.kt
+++ b/src/main/kotlin/com/example/routes/leaderboard/leaderboardRouter.kt
@@ -1,0 +1,59 @@
+package com.example.routes.leaderboard
+
+import com.example.plugins.toObject
+import com.example.routes.githubEvents.GithubUser
+import com.wehuddle.db.tables.PullRequest
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import java.time.OffsetDateTime
+import org.jooq.DSLContext
+import org.jooq.JSONB
+import org.jooq.impl.DSL
+
+private val PULL_REQUEST = PullRequest.PULL_REQUEST
+
+fun Route.leaderboard(context: DSLContext) {
+    route("/leaderboard/{timePeriod}") {
+        get {
+            val now = OffsetDateTime.now()
+            val (startDate: OffsetDateTime, endDate: OffsetDateTime) = when(LeaderboardPeriod.valueOf(call.parameters["timePeriod"]!!)) {
+                LeaderboardPeriod.current -> {
+                    listOf(
+                        now.withDayOfMonth(1)
+                            .withHour(0).withMinute(0).withSecond(0),
+                        now
+                    )
+                }
+                LeaderboardPeriod.last -> {
+                    listOf(
+                        now.minusMonths(1)
+                            .withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0),
+                        now.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0),
+                    )
+                }
+                LeaderboardPeriod.all -> {
+                    listOf(OffsetDateTime.now().withYear(1970), now)
+                }
+            }
+            val fetchedRecords = context
+                .select(DSL.jsonbObjectAgg(PULL_REQUEST.GITHUB_USER), DSL.count())
+                .from(PULL_REQUEST)
+                .where(PULL_REQUEST.OPENED_AT.between(startDate).and(endDate))
+                .and(PULL_REQUEST.MERGED)
+                .groupBy(PULL_REQUEST.GITHUB_USER)
+                .fetch()
+            val leaderboardRecords = mutableListOf<LeaderboardRecord>();
+            for (record in fetchedRecords) {
+                val githubUser = (record.get(0) as JSONB).data().toObject(GithubUser::class.java)
+                val points = (record.get(1) as Int) * 10
+                leaderboardRecords.add(LeaderboardRecord(points, githubUser))
+            }
+            leaderboardRecords.sortByDescending { leaderboardRecord -> leaderboardRecord.points }
+            call.respond(HttpStatusCode.OK, leaderboardRecords)
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to implement a new feature for leaderboards 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
To provide an endpoint to get leaderboard details 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Made an endpoint to get all-time, last month and current month leaderboard records
- Used GitHub user column to group together pull requests and calculate the points 

## Checklist
  - [x] Newly introduced environment variables are added to the hosted dev server 
  - [x] Generated the newly added database entities by running `migrate.sh`

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
